### PR TITLE
Refactor scraper pipeline: Decouple fetch, parse and output stages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ wheels/
 # Virtual environments
 .venv
 
-#log files
-
+#log files 
 .log
 .json
+

--- a/src/fetch_html.py
+++ b/src/fetch_html.py
@@ -1,0 +1,73 @@
+import time
+from datetime import datetime
+import uuid
+from urllib.parse import urlparse
+import requests
+from log_data import log_events
+from bs4 import BeautifulSoup
+
+
+class FetchHtml():
+    def __init__(self):
+        self.max_tries = 3
+        self.timeout = 5
+        self.user_agent = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:145.0) Gecko/20100101 Firefox/145.0'}
+        self.status = ''
+        self.unique_url = ''
+        self.result_list_fetcher = {}
+
+
+    def export_results(self):
+        
+        self.result_list_fetcher = {
+            'unique_hash': self.unique_hash,
+            'url': self.unique_url,
+            'domain': self.domain,
+            'date_scraped': self.date_scraped,
+            'status': self.status
+        }
+
+            
+
+    def fetch_sites(self, url):
+
+        time_in_milliseconds = round(time.time() * 1000)
+
+
+        try:
+            self.unique_hash = uuid.uuid4()
+            self.domain = urlparse(url).netloc
+            self.date_scraped = datetime.now().isoformat()
+            self.unique_url = url
+
+            response = requests.get(url, allow_redirects=True, timeout=self.timeout, headers=self.user_agent)
+            log_events(url,response.reason, time_in_milliseconds)
+
+            if response.status_code == 200:
+                print(f'success {self.domain}')
+                self.status = 'success'
+                self.export_results()
+                return BeautifulSoup(response.content, 'html.parser') #return html to be parsed
+
+            else:
+                self.status = 'failed'
+                for retry in range(self.max_tries):
+                    response = requests.get(url, allow_redirects=True, timeout=self.timeout, headers=self.user_agent)
+                    log_events(url,response.reason, time_in_milliseconds)
+                    if response.status_code == 200:
+                        self.status = 'success'
+                        self.export_results()
+                        return BeautifulSoup(response.content, 'html.parser') #return html to be parsed
+
+                    #exponentional backoff
+                    time.sleep(2 ** retry)
+                
+                self.export_results()
+                                
+        except requests.RequestException as error:
+            self.status = 'failed'
+            log_events(url, error , time_in_milliseconds)
+            print(f'Error during request: {error}')
+            self.export_results()
+
+

--- a/src/log_data.py
+++ b/src/log_data.py
@@ -1,13 +1,14 @@
 import logging
 import time
-import re
+from datetime import datetime
 
 #logger setup
 file_logger = logging.getLogger('url_events')
 file_logger.setLevel(logging.INFO)
+date_now = datetime.now().strftime("%Y_%m_%dT%H_%M_%S_%f")
 
 if not file_logger.handlers:
-    handler = logging.FileHandler('../logs/logs_url_event.log')
+    handler = logging.FileHandler(f'./logs/logs_url_event_{date_now}.log')
     formatter = logging.Formatter(
         '%(asctime)s - %(url)s - %(levelname)s - %(status)s - %(duration)s'
     )

--- a/src/main.py
+++ b/src/main.py
@@ -1,13 +1,14 @@
+from scrape_static_data import ScrapeStaticData
+
 
 def main():
     #code to check if site is static or dynamic
 
     #call class if static
+    static_scrape_class = ScrapeStaticData()
+    static_scrape_class.run_scraper()
 
     #call class if dynamic
-
-    pass
-
 
 
 

--- a/src/parse_html.py
+++ b/src/parse_html.py
@@ -1,0 +1,195 @@
+
+
+
+class ParseHTML():
+    def __init__(self):
+
+
+        self.title = ''
+        self.author = ''
+        self.date_published = ''
+        self.clean_text = ''
+        self.links = []
+        self.tags = []
+        self.raw_html_length = '' 
+
+        self.result_list_parser = {}
+
+
+    def export_results(self):
+        self.result_list_parser =  {
+                'title': self.title,
+                'author': self.author,
+                'date_published': self.date_published,
+                'clean_text': self.clean_text,
+                'links': self.links,
+                'tags': self.tags,
+                'raw_html_length': self.raw_html_length,
+            }
+        
+
+    def scrape_html(self, html):
+             
+            if html is None: #check if fetcher had an exception/error
+                self.title = ''
+                self.author = ''
+                self.date_published = ''
+                self.clean_text = ''
+                self.links = []
+                self.tags = []
+                self.raw_html_length = '' 
+                self.export_results() #needed to prevent outputing previous results.
+                return 'Cannot Parse Html due to error Fetching.'
+            
+            self.raw_html_length = len(str(html)) 
+
+            title = ""
+
+            og_title = html.find("meta", attrs={"property": "og:title"})
+            if og_title and og_title.get("content"):
+                title = og_title["content"].strip()
+
+            if not title and html.title and html.title.string:
+                title = html.title.string.strip()
+
+            if not title:
+                h1 = html.find("h1")
+                if h1:
+                    title = h1.get_text(" ", strip=True)
+
+            self.title = title
+
+            main_container = html.find("article")
+            if main_container is None:
+                main_container = html.find("main")
+
+            if main_container is None:
+                main_container = html.find(
+                    "div",
+                    attrs={"id": lambda v: isinstance(v, str) and "content" in v.lower()},
+                )
+
+            if main_container is None:
+                main_container = html.find(
+                    "div",
+                    attrs={"class": lambda v: isinstance(v, str) and "content" in v.lower()},
+                )
+
+            paragraphs = []
+
+
+            pass
+            if main_container:
+                paragraph_nodes = main_container.find_all("p")
+            else:
+                paragraph_nodes = html.find_all("p")
+
+
+            #title
+            for p in paragraph_nodes:
+                text = p.get_text(" ", strip=True)
+                if text:
+                    paragraphs.append(text)
+
+            text_joined = "\n\n".join(paragraphs)
+
+            if not text_joined or len(text_joined.split()) < 50:
+                if main_container:
+                    fallback_text = main_container.get_text(" ", strip=True)
+                    if fallback_text and len(fallback_text.split()) > len(text_joined.split()):
+                        text_joined = fallback_text
+
+            if not text_joined:
+                whole_page_text = html.get_text(" ", strip=True)
+                if whole_page_text:
+                    text_joined = whole_page_text
+
+            self.clean_text = text_joined
+
+            if main_container:
+                link_nodes = main_container.find_all("a", href=True)
+            else:
+                link_nodes = html.find_all("a", href=True)
+
+            links = []
+            for a in link_nodes:
+                href = a["href"].strip()
+                if href:
+                    links.append(href)
+
+            self.links = links
+
+            author = ""
+
+            meta_author = html.find("meta",attrs={"name": "author"})
+            if meta_author and meta_author.get("content"):
+                author = meta_author["content"].strip()
+
+            if not author:
+                meta_author = html.find("meta",attrs={"property": "article:author"})
+                if meta_author and meta_author.get("content"):
+                    author = meta_author["content"].strip()
+
+            if not author:
+                byline = html.find(
+                    attrs={
+                        "class": lambda v: (
+                            isinstance(v, str)
+                            and ("author" in v.lower() or "byline" in v.lower())
+                        )
+                    }
+                )
+                if byline:
+                    author = byline.get_text(" ", strip=True)
+
+            self.author = author
+
+            date_value = ""
+
+            date_meta_candidates = [
+                {"property": "article:published_time"},
+                {"name": "pubdate"},
+                {"name": "date"},
+                {"name": "DC.date.issued"},
+            ]
+
+            for attrs in date_meta_candidates:
+                meta = html.find("meta", attrs=attrs)
+                if meta and meta.get("content"):
+                    date_value = meta["content"].strip()
+                    break
+
+            if not date_value:
+                time_tag = html.find("time")
+                if time_tag:
+                    datetime_attr = time_tag.get("datetime")
+                    if datetime_attr:
+                        date_value = datetime_attr.strip()
+                    else:
+                        date_value = time_tag.get_text(" ", strip=True)
+
+
+            self.date_published = date_value
+
+
+            tags = []
+            meta_keywords = html.find("meta", attrs={"name": "keywords"})
+            if meta_keywords and meta_keywords.get("content"):
+                raw_keywords = meta_keywords["content"]
+                tags = [kw.strip() for kw in raw_keywords.split(",") if kw.strip()]
+
+
+            self.tags = tags
+
+
+            word_count = len(self.clean_text.split())
+            if word_count > 0:
+                self.read_time_minutes = max(1, round(word_count / 200))
+            else:
+                self.read_time_minutes = 0
+
+
+
+            
+            self.export_results()
+

--- a/src/scrape_static_data.py
+++ b/src/scrape_static_data.py
@@ -1,276 +1,49 @@
-import requests
-from bs4 import BeautifulSoup
-import time
-from urllib.parse import urlparse
-import orjson
-import uuid
-from datetime import datetime
-import log_data
-import yaml
-
-class ScrapeStaticData():
-
-
-    def __init__(self, urls):
-        self.urls = urls
-        self.content_type = ''
-        self.unique_hash = None #populated by fetch site
-        self.domain = '' #populated by fetch site
-        self.date_now = ''#populated by fetch site
-        self.user_agent = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:145.0) Gecko/20100101 Firefox/145.0'}
-
-        self.clean_text = '' #populated by extract_text
-        self.author = '' #populated by extract_text
-        self.title = '' #populated by extract_text
-        self.date_published = '' #populated by extract_text
-        self.links = []
-        self.tags = []
-        self.raw_html_length = '' 
-
-
-
-    
-    def current_milli_time(self):
-        return round(time.time() * 1000)
-    
-    def set_site_attributes(self, url_given):
-        self.unique_hash = uuid.uuid4()
-        self.domain = urlparse(url_given).netloc
-        self.date_now = datetime.now().isoformat()
-
-    def fetch_site(self, url, max_tries, timeout):
-        self.set_site_attributes(url)
-        
-        time_in_milliseconds = self.current_milli_time()
-
-
-        for retry in range(max_tries):
-            try:
-                response = requests.get(url, allow_redirects=True, timeout=timeout, headers=self.user_agent)
-
-                if response.status_code == 200:
-                    print(f'success {self.domain}')
-                    soup = BeautifulSoup(response.content, 'html.parser')      
-                    self.extract_text(soup)                                    
-                    self.return_json_output()                                  
-                    self.log_events(url, response.status_code, time_in_milliseconds)
-                    return soup
-
-
-
-                else:
-                    log_data.log_events(url,response.reason, time_in_milliseconds)
-                    print('Failed to fetch page.' \
-                        f'HTTP Status Code: {response.status_code}.' \
-                        f'Domain: {self.domain}' \
-                        'Retrying in {2 ** retry} seconds...')
-                                                
-                    #exponentional backoff
-                    time.sleep(2 ** retry)
-                
-            except requests.RequestException as e:
-                log_data.log_events(url, e , time_in_milliseconds)
-                print(f'Error during request: {e}')
-                return
-        
-
-
-
-    def fetch_urls(self):
-        for url in self.urls:
-            self.fetch_site(url, max_tries=3,
-                                        timeout=5)
-
-
-
-
-    def log_events(self, problem, url, time_in_milliseconds):
-        duration_end = self.current_milli_time()
-        run_time_ms =  duration_end - time_in_milliseconds
-
-        log_info = {
-            'url': url,
-            'status': problem,
-            'duration': str(run_time_ms)+'ms',
-        }
-
-        logging.info("Logged Info", extra=log_info)
-        
-
-
-
-    def extract_text(self, soup):
-
-        self.raw_html_length = len(str(soup)) # sets raw_html_length var to length of soup(parsed html's len)
-
-        title = ""
-
-        og_title = soup.find("meta", attrs={"property": "og:title"})
-        if og_title and og_title.get("content"):
-            title = og_title["content"].strip()
-
-        if not title and soup.title and soup.title.string:
-            title = soup.title.string.strip()
-
-        if not title:
-            h1 = soup.find("h1")
-            if h1:
-                title = h1.get_text(" ", strip=True)
-
-        self.title = title
-
-        main_container = soup.find("article")
-        if main_container is None:
-            main_container = soup.find("main")
-
-        if main_container is None:
-            main_container = soup.find(
-                "div",
-                attrs={"id": lambda v: isinstance(v, str) and "content" in v.lower()},
-            )
-
-        if main_container is None:
-            main_container = soup.find(
-                "div",
-                attrs={"class": lambda v: isinstance(v, str) and "content" in v.lower()},
-            )
-
-        paragraphs = []
-
-        if main_container:
-            paragraph_nodes = main_container.find_all("p")
-        else:
-            paragraph_nodes = soup.find_all("p")
-
-        for p in paragraph_nodes:
-            text = p.get_text(" ", strip=True)
-            if text:
-                paragraphs.append(text)
-
-        text_joined = "\n\n".join(paragraphs)
-
-        if not text_joined or len(text_joined.split()) < 50:
-            if main_container:
-                fallback_text = main_container.get_text(" ", strip=True)
-                if fallback_text and len(fallback_text.split()) > len(text_joined.split()):
-                    text_joined = fallback_text
-
-        if not text_joined:
-            whole_page_text = soup.get_text(" ", strip=True)
-            if whole_page_text:
-                text_joined = whole_page_text
-
-        self.clean_text = text_joined
-
-        if main_container:
-            link_nodes = main_container.find_all("a", href=True)
-        else:
-            link_nodes = soup.find_all("a", href=True)
-
-        links = []
-        for a in link_nodes:
-            href = a["href"].strip()
-            if href:
-                links.append(href)
-
-        self.links = links
-
-        author = ""
-
-        meta_author = soup.find("meta",attrs={"name": "author"})
-        if meta_author and meta_author.get("content"):
-            author = meta_author["content"].strip()
-
-        if not author:
-            meta_author = soup.find("meta",attrs={"property": "article:author"})
-            if meta_author and meta_author.get("content"):
-                author = meta_author["content"].strip()
-
-        if not author:
-            byline = soup.find(
-                attrs={
-                    "class": lambda v: (
-                        isinstance(v, str)
-                        and ("author" in v.lower() or "byline" in v.lower())
-                    )
-                }
-            )
-            if byline:
-                author = byline.get_text(" ", strip=True)
-
-        self.author = author
-
-        date_value = ""
-
-        date_meta_candidates = [
-            {"property": "article:published_time"},
-            {"name": "pubdate"},
-            {"name": "date"},
-            {"name": "DC.date.issued"},
-        ]
-
-        for attrs in date_meta_candidates:
-            meta = soup.find("meta", attrs=attrs)
-            if meta and meta.get("content"):
-                date_value = meta["content"].strip()
-                break
-
-        if not date_value:
-            time_tag = soup.find("time")
-            if time_tag:
-                datetime_attr = time_tag.get("datetime")
-                if datetime_attr:
-                    date_value = datetime_attr.strip()
-                else:
-                    date_value = time_tag.get_text(" ", strip=True)
-
-        self.date_published = date_value
-
-        tags = []
-        meta_keywords = soup.find("meta", attrs={"name": "keywords"})
-        if meta_keywords and meta_keywords.get("content"):
-            raw_keywords = meta_keywords["content"]
-            tags = [kw.strip() for kw in raw_keywords.split(",") if kw.strip()]
-
-        self.tags = tags
-
-        word_count = len(self.clean_text.split())
-        if word_count > 0:
-            self.read_time_minutes = max(1, round(word_count / 200))
-        else:
-            self.read_time_minutes = 0
-
-
-    def return_json_output(self):
-        json_schema = {
-            'id': self.unique_hash,
-            'source_url': url,
-            'source_domain': self.domain,
-            'scraped_at': self.date_now,
-            'content_type': self.content_type,
-            'title': self.title,
-            'author': self.author,
-            'published_date': self.date_published,
-            'text': self.clean_text,
-            'links': self.links,
-            'metadata': {
-                'tags': self.tags,
-                'raw_html_length': self.raw_html_length
-            }
-        }
-
-        with open('../logs/scraper_json_output.json', 'a') as scraper_output:
-            scraper_output.write(f"{orjson.dumps(json_schema).decode()}\n\n")
-
-
-
-def return_config_urls():
-    with open('urls.yaml', 'r') as config:
+from fetch_html import FetchHtml
+from  parse_html import ParseHTML
+from scraper_output import ScraperOutput
+import os 
+import yaml 
+
+def return_config_urls() -> str:
+    print(os.getcwd())
+    with open('./src/urls.yaml', 'r') as config:
         loaded_config = yaml.safe_load(config)
 
     return loaded_config['urls']
 
 
+class ScrapeStaticData():
 
-class_instance = ScrapeStaticData(urls=return_config_urls())
-class_instance.fetch_urls()
+
+    def __init__(self):
+        self.fetch_html_class = FetchHtml()
+        self.parse_html_class = ParseHTML()
+        self.urls = return_config_urls()
+        self.scraper_data = {}
+
+    
+
+
+    def run_scraper(self):
+
+
+        for site in self.urls:
+            html = self.fetch_html_class.fetch_sites(site)
+
+            self.parse_html_class.scrape_html(html)
+            fetcher_results = self.fetch_html_class.result_list_fetcher
+            parser_results = self.parse_html_class.result_list_parser
+            
+            self.scraper_data.update(fetcher_results)
+            self.scraper_data.update(parser_results)
+
+            scraper_output = ScraperOutput(self.scraper_data)
+            scraper_output.scraper_json_output()
+
+            self.scraper_data.clear()
+            
+
+            
+
+class_instance = ScrapeStaticData()
+result = class_instance.run_scraper()

--- a/src/scraper_output.py
+++ b/src/scraper_output.py
@@ -1,0 +1,34 @@
+
+import orjson 
+
+
+class ScraperOutput():
+    def __init__(self, scraper_data:dict):
+        for key, value in scraper_data.items():
+            setattr(self, key, value)
+        
+        self.content_type = "Place Holder" #Pass LLM content_type here
+
+    def scraper_json_output(self):
+            
+        json_schema = {
+            'unique_hash': self.unique_hash,
+            'unique_url': self.url,
+            'domain': self.domain,
+            'date_scraped': self.date_scraped,
+            'content_type': self.content_type,
+            'title': self.title,
+            'author': self.author,
+            'date_published': self.date_published,
+            'clean_text': self.clean_text,
+            'links': self.links,
+            'status': self.status,
+            'metadata': {
+                'tags': self.tags,
+                'raw_html_length': self.raw_html_length
+            }
+        }
+
+
+        
+        return print(orjson.dumps(json_schema).decode())


### PR DESCRIPTION
### Problem

The old system relied on a single god class to basically do everything from scraping to outputting which resulted in classic problems like :

- Hard to extend functionality without breaking everything
- 300 + lines of code for a comparatively simple static html scraper
- Unpredictable behavior. Especially Scraper Output due to a shared state.

### Solution

- Added FetchHtml, ParseHtml, and ScraperOutput classes 

- FetchHtml and ParseHtml return json schemas with their respective results 
for ScraperOutput to then piece togather in a cohesive Json output.

- The scrape_static_data script is now only reserved as a sort of orchestra 
to have the scraper run in the correct process.